### PR TITLE
tx-load: add binaries to initialize users on chain and to submit transactions

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,9 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.7-labs
 # The above line enables experimental features (namely, `COPY --exclude`)
 
-# Add the "code" build context to access local source code during build.
-#  docker build . --build-context code=$SNAPCHAIN_DIR
-
 FROM rust:1.85 AS builder
 
 RUN apt-get update && apt-get install -y libclang-dev git libjemalloc-dev llvm-dev make protobuf-compiler libssl-dev openssh-client cmake
@@ -37,8 +34,8 @@ WORKDIR /usr/src/app
 # since the Cargo configuration references files in src.
 # This means we'll re-fetch all crates every time the source code changes,
 # which isn't ideal.
-COPY --from=code ./Cargo.toml ./build.rs ./
-COPY --from=code --exclude=src/bin src ./src
+COPY ../Cargo.toml ../build.rs ./
+COPY --exclude=../src/bin ../src ./src
 
 ENV RUST_BACKTRACE=full
 RUN --mount=type=cache,target=/usr/local/cargo/registry cargo build --release

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -26,6 +26,10 @@ setup:
 
 start:
 	docker compose up -d
+	cargo run --bin testnet_init_users
+
+load:
+	cargo run --bin testnet_submit_messages
 
 stop:
 	docker compose down --remove-orphans --volumes

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -19,14 +19,10 @@ TERRAFORM_VARS := -var='testnet_dir=$(TESTNET_DIR)' \
 IMAGE_NAME := snapchain-node
 
 build:
-	time docker build -t $(IMAGE_NAME) --platform linux/amd64 --build-context "code=.." .
-	
-build-config:	
-	cargo build --bin setup_e2e_testnet
-	cargo build --bin setup_remote_testnet
+	time docker build -t $(IMAGE_NAME)-local .
 
 setup:
-	../target/debug/setup_e2e_testnet
+	cargo run --bin setup_e2e_testnet
 
 start:
 	docker compose up -d
@@ -53,11 +49,15 @@ sync-debug:
 
 .PHONY: build setup start stop clean perturb sync-debug 
 
+remote-build:
+	time docker build -t $(IMAGE_NAME) --platform linux/amd64 .
+
 remote-create:
 	cd terraform && time terraform apply -parallelism=200 $(TERRAFORM_VARS)
 
+# Locally create the nodes' config files.
 remote-setup:
-	../target/debug/setup_remote_testnet --topology default
+	cargo run --bin setup_remote_testnet -- --topology default
 
 remote-destroy:
 	cd terraform && time terraform destroy -parallelism=200 $(TERRAFORM_VARS)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -47,9 +47,9 @@ The testnet will be deployed to DigitalOcean.
 
 5. Before creating the remote nodes, the Docker image should exist locally. Build it with:
     ```sh
-    make build
+    make remote-build
     ```
-    This command creates an image with the tag `snapchain-node`.
+    This command creates an image with the tag `snapchain-node` and it may take a rather long time to compile.
 
 ### Run the testnet
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,6 +7,7 @@ Run the testnet with:
 make build
 make setup
 make start
+make load
 make perturb
 make stop
 make clean

--- a/src/bin/setup_e2e_testnet.rs
+++ b/src/bin/setup_e2e_testnet.rs
@@ -151,12 +151,20 @@ async fn main() {
             Some(number) => format!("stop_block_number = {number}").to_string(),
         };
 
+        // If this is the first node, enable an admin service
+        let admin_rpc_auth = if id == 1 {
+            "admin_rpc_auth=\"user:test\""
+        } else {
+            ""
+        };
+
         let config_file_content = format!(
             r#"
 rpc_address="{rpc_address}"
 http_address="{http_address}"
 rocksdb_dir="{db_dir}"
 l1_rpc_url="{l1_rpc_url}"
+{admin_rpc_auth}
 
 [statsd]
 prefix="{statsd_prefix}"

--- a/src/bin/testnet_init_users.rs
+++ b/src/bin/testnet_init_users.rs
@@ -1,0 +1,77 @@
+use clap::Parser;
+use ed25519_dalek::SigningKey;
+use snapchain::proto;
+use snapchain::proto::admin_service_client::AdminServiceClient;
+use snapchain::storage::store::test_helper;
+use snapchain::utils::cli;
+use snapchain::utils::cli::send_on_chain_event;
+use snapchain::utils::factory::events_factory;
+use std::error::Error;
+use std::{env, panic, process};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// RPC address of the node running the admin service
+    #[arg(long, default_value = "http://127.0.0.1:3383")]
+    admin_rpc_addr: String,
+
+    /// Authentication credentials for the admin service
+    #[arg(long, default_value = "user:test")]
+    auth: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    env::set_var("RUST_BACKTRACE", "1");
+    panic::set_hook(Box::new(|panic_info| {
+        eprintln!("Panic occurred: {}", panic_info);
+        // let backtrace = std::backtrace::Backtrace::capture();
+        // eprintln!("Stack trace:\n{}", backtrace);
+        process::exit(1);
+    }));
+
+    let args = Args::parse();
+
+    let mut admin_client = AdminServiceClient::connect(args.admin_rpc_addr.clone())
+        .await
+        .unwrap_or_else(|e| panic!("Error connecting to {}: {}", &args.admin_rpc_addr, e));
+
+    let private_key = test_helper::default_signer();
+
+    // Initialize only two users for testing
+    let fids = vec![1_000_001, 1_000_002];
+
+    for fid in fids {
+        println!("Initializing user with FID: {}", fid);
+        for event in user_events(private_key.clone(), fid) {
+            if let Err(e) = send_on_chain_event(&mut admin_client, &event, args.auth.clone()).await
+            {
+                panic!("Failed to send on-chain event: {:?}", e);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Generates a list of on-chain events required to initialize a user with the
+/// given FID.
+fn user_events(private_key: SigningKey, fid: u64) -> Vec<proto::OnChainEvent> {
+    vec![
+        cli::compose_rent_event(fid),
+        events_factory::create_id_register_event(
+            fid,
+            proto::IdRegisterEventType::Register,
+            vec![],
+            None,
+        ),
+        events_factory::create_signer_event(
+            fid,
+            private_key,
+            proto::SignerEventType::Add,
+            None,
+            None,
+        ),
+    ]
+}

--- a/src/bin/testnet_submit_messages.rs
+++ b/src/bin/testnet_submit_messages.rs
@@ -1,0 +1,44 @@
+use clap::Parser;
+use snapchain::proto::hub_service_client::HubServiceClient;
+use snapchain::storage::store::test_helper;
+use snapchain::utils::cli;
+
+#[derive(Parser)]
+struct Cli {
+    #[arg(long, default_value = "http://127.0.0.1:3383")]
+    addr: String,
+
+    #[arg(long, default_value = "100")]
+    num: usize,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Cli::parse();
+    let rpc_addr = args.addr;
+    let num = args.num;
+
+    let private_key = test_helper::default_signer();
+
+    let mut client = HubServiceClient::connect(rpc_addr.clone())
+        .await
+        .unwrap_or_else(|e| panic!("Error connecting to {}: {}", &rpc_addr, e));
+
+    // Fixed user FID for testing
+    let fid = 1_000_001;
+
+    let mut success = 0;
+    for i in 1..num + 1 {
+        let text = format!("Test message: {}", i);
+        let msg = cli::compose_message(fid, &text, None, Some(&private_key));
+        let resp = cli::send_message(&mut client, &msg, None).await;
+
+        if resp.is_ok() {
+            success += 1;
+        } else {
+            eprintln!("Failed to send message {}: {:?}", i, resp.err());
+        }
+    }
+
+    println!("Submitted {} messages, {} succeeded", num, success);
+}


### PR DESCRIPTION
Closes #3 

This PR adds the binaries 
- `testnet_init_users`, for initializing two user FIDs in the local testnet, and 
- `testnet_submit_messages`, for submitting transactions to a node from one of the users.

After running `testnet_init_users`, wait a few seconds before sending transactions, so that the user registration is propagated in the network.

These currently works in the local testnet, not on remote.